### PR TITLE
Support for Test::Unit 2.1

### DIFF
--- a/lib/ci/reporter/rake/test_unit_loader.rb
+++ b/lib/ci/reporter/rake/test_unit_loader.rb
@@ -1,3 +1,4 @@
+
 # Copyright (c) 2006-2010 Nick Sieger <nicksieger@gmail.com>
 # See the file LICENSE.txt included with the distribution for
 # software license details.
@@ -5,6 +6,7 @@
 $: << File.dirname(__FILE__) + "/../../.."
 require 'ci/reporter/test_unit'
 
+# Intercepts mediator creation in ruby-test < 2.1
 module Test #:nodoc:all
   module Unit
     module UI
@@ -14,6 +16,20 @@ module Test #:nodoc:all
             # swap in our custom mediator
             return CI::Reporter::TestUnit.new(suite)
           end
+        end
+      end
+    end
+  end
+end
+
+# Intercepts mediator creation in ruby-test >= 2.1
+module Test #:nodoc:all
+  module Unit
+    module UI
+      class TestRunner
+        def setup_mediator
+          # swap in our custom mediator
+          @mediator = CI::Reporter::TestUnit.new(@suite)
         end
       end
     end


### PR DESCRIPTION
CI_Reporter currently does not work with Test::Unit 2.1 because the code path for creating the mediator, which CI_Reporter hooks into, changed between Test::Unit 2.0 and 2.1.

The attached pull request contains a change to test_unit_loader.rb that allows CI_Reporter to hook into Test::Unit 2.1, without breaking support for older versions of Test::Unit.
