### PR TITLE
Fix for Issue #10 - ci_reporter tries to create a file with a name component > 255 characters

### DIFF
--- a/spec/ci/reporter/report_manager_spec.rb
+++ b/spec/ci/reporter/report_manager_spec.rb
@@ -36,4 +36,16 @@ describe "The ReportManager" do
     File.exist?(filename).should be_true
     File.open(filename) {|f| f.read.should == "<xml></xml>"}
   end
+
+  it "should not write files with names longer than 255 characters" do
+    reporter = CI::Reporter::ReportManager.new("spec")
+    suite = mock("test suite")
+    suite.should_receive(:name).and_return("some " + ("long " * 50) + " suite name")
+    suite.should_receive(:to_xml).and_return("<xml></xml>")
+    reporter.write_report(suite)
+
+    files = Dir["#{REPORTS_DIR}/SPEC-some-long-long-long-long*.xml"]
+    files.size.should == 1
+    files.first.split('/').last.size.should <= 255
+  end
 end


### PR DESCRIPTION
This pull request contains a fix for #10.

It follows the proposed implementation strategy and shortens file names longer than 255 characters. In order to keep them uniq, a SHA1 hash of the remaining string is attached to the name.
