### PR TITLE
Fix for "File name too long" error with RSpec on Linux

### DIFF
--- a/lib/ci/reporter/report_manager.rb
+++ b/lib/ci/reporter/report_manager.rb
@@ -7,16 +7,38 @@ require 'fileutils'
 module CI #:nodoc:
   module Reporter #:nodoc:
     class ReportManager
+      UNIQUE_SUFFIX_LENGTH = 8
+
       def initialize(prefix)
         @basedir = ENV['CI_REPORTS'] || File.expand_path("#{Dir.getwd}/#{prefix.downcase}/reports")
         @basename = "#{@basedir}/#{prefix.upcase}"
+        @max_filename_length = ENV['CI_MAX_FILENAME_LENGTH'].to_i
+        if @max_filename_length != 0
+          min_acceptable_max = UNIQUE_SUFFIX_LENGTH + '.xml'.length
+          unless @max_filename_length > min_acceptable_max
+            raise ArgumentError, "CI_MAX_FILENAME_LENGTH must exceed #{min_acceptable_max}!"
+          end
+          @max_filename_length -= '.xml'.length
+        end
         FileUtils.mkdir_p(@basedir)
       end
       
       def write_report(suite)
-        File.open("#{@basename}-#{suite.name.gsub(/[^a-zA-Z0-9]+/, '-')}.xml", "w") do |f|
+        File.open(report_filename(suite), "w") do |f|
           f << suite.to_xml
         end
+      end
+
+      private
+      def report_filename(suite)
+        ideal = "#{@basename}-#{suite.name.gsub(/[^a-zA-Z0-9]+/, '-')}"
+
+        if @max_filename_length == 0 || ideal.length <= @max_filename_length
+          return "#{ideal}.xml"
+        end
+
+        suffix = "%0#{UNIQUE_SUFFIX_LENGTH}d" % rand(10 ** UNIQUE_SUFFIX_LENGTH)
+        ideal[0, @max_filename_length - UNIQUE_SUFFIX_LENGTH] + suffix + '.xml'
       end
     end
   end


### PR DESCRIPTION
Hi, when I use `ci:setup:rspec` in my Rake task on Linux about halfway through the spec run I get the following error:

```
/var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@global/gems/ci_reporter-1.6.4.1/lib/ci/reporter/rake/../../../ci/reporter/report_manager.rb:27:in `initialize': File name too long - /var/lib/jenkins/jobs/<WHAT IS ADMITTEDLY A VERY LONG FILE NAME>.xml (Errno::ENAMETOOLONG)
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@global/gems/ci_reporter-1.6.4.1/lib/ci/reporter/rake/../../../ci/reporter/report_manager.rb:27:in `open'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@global/gems/ci_reporter-1.6.4.1/lib/ci/reporter/rake/../../../ci/reporter/report_manager.rb:27:in `write_report'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@global/gems/ci_reporter-1.6.4.1/lib/ci/reporter/rake/../../../ci/reporter/rspec.rb:172:in `write_report'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@global/gems/ci_reporter-1.6.4.1/lib/ci/reporter/rake/../../../ci/reporter/rspec.rb:176:in `new_suite'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@global/gems/ci_reporter-1.6.4.1/lib/ci/reporter/rake/../../../ci/reporter/rspec.rb:92:in `example_group_started'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/runner/reporter.rb:19:in `example_group_started'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/runner/reporter.rb:18:in `each'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/runner/reporter.rb:18:in `example_group_started'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/example/example_group_methods.rb:115:in `notify'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/example/example_group_methods.rb:96:in `run'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/runner/example_group_runner.rb:23:in `run'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/runner/example_group_runner.rb:22:in `each'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/runner/example_group_runner.rb:22:in `run'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/runner/options.rb:152:in `run_examples'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/lib/spec/runner/command_line.rb:9:in `run'
  from /var/lib/jenkins/.rvm/gems/ruby-1.8.7-p334@rapportive/gems/rspec-1.3.0/bin/spec:5
```

To avoid this error, I've added an environment variable CI_MAX_FILENAME_LENGTH which, if set, truncates any generated XML files whose absolute file path would exceed that length.  It adds a randomly generated suffix to each truncated file to avoid overwrites from name conflicts.  With this change (and CI_MAX_FILENAME_LENGTH set to 150) we're able to run our substantial body of RSpec tests on our Linux CI machine and have Jenkins report the results nicely as intended.

Please would you consider accepting this patch into your official repo?

Thanks,
Sam Stokes
Rapportive
