### PR TITLE
Better rspec 2.0 support

### DIFF
--- a/lib/ci/reporter/rspec.rb
+++ b/lib/ci/reporter/rspec.rb
@@ -65,10 +65,9 @@ module CI
         output.push @exception.message
 
         @formatter.format_backtrace(@exception.backtrace, @example).each do |backtrace_info|
-          output.push backtrace_info
+          output.push "     #{backtrace_info}"
         end
-        
-        output.join '\n'
+        output.join "\n"
       end
     end
 


### PR DESCRIPTION
Here are some tweaks I made to provide slightly better RSpec 2.0 integration in my project.  I can break these out into separate pulls if you like.  This fixes:

1) Formatting of the documentation output when using the documation formatter with ci_reporter.  'example_group_finished' wasn't being called, so it never reduced the indentation level
2) 'dump_failures' wasn't being called, so when using the ci_reporter it wouldn't dump out failures the way it normally does
3) Stack traces weren't being formatted the rspec usually does it.  RSpec will show a simplified stacktrace depicting only your test, unless you explicitly pass an option enabling full stack traces.  The abbreviated stack traces are now what end up in the junit output, unless you specify you want the full dump.
