### PR TITLE
RSpec base formatter

### DIFF
--- a/lib/ci/reporter/rake/rspec.rb
+++ b/lib/ci/reporter/rake/rspec.rb
@@ -21,5 +21,11 @@ namespace :ci do
         "--format", "CI::Reporter::RSpecDoc"].join(" ")
       ENV["SPEC_OPTS"] = "#{ENV['SPEC_OPTS']} #{spec_opts}"
     end
+
+    task :rspecbase => :spec_report_cleanup do
+      spec_opts = ["--require", CI::Reporter.maybe_quote_filename("#{File.dirname(__FILE__)}/rspec_loader.rb"),
+        "--format", "CI::Reporter::RSpecBase"].join(" ")
+      ENV["SPEC_OPTS"] = "#{ENV['SPEC_OPTS']} #{spec_opts}"
+    end
   end
 end

--- a/lib/ci/reporter/rspec.rb
+++ b/lib/ci/reporter/rspec.rb
@@ -205,5 +205,12 @@ module CI
         super
       end
     end
+
+    class RSpecBase < RSpec
+      def initialize(*args)
+        @formatter = RSpecFormatters::BaseFormatter.new(*args)
+        super
+      end
+    end
   end
 end


### PR DESCRIPTION
RSpec 2 allows you to use multiple formatters.  I'm wanting to use a custom documentation formatter in my project along with CI reporter.  However, the two ci_reporter formatters both delegate to either the documentation formatter or the base text formatter.  This means if I make my own documentation formatter, I get the two outputs interleaved.

So I made a CI RSpec formatter that delegates to the base formatter.  This will keep it from printing anything and interfering with my custom text formatters.

Though, I think for RSpec 2 at least, it might make sense to have the CI RSpec formatter not delegate at all, since the end user can use whatever other formatters as they want.
