### PR TITLE
Fix for Errno::ENAMETOOLONG

### DIFF
--- a/lib/ci/reporter/report_manager.rb
+++ b/lib/ci/reporter/report_manager.rb
@@ -33,11 +33,17 @@ module CI #:nodoc:
       #   SPEC-MailsController.N.xml
       #
       # with N < 100000, to prevent endless sidestep loops
-      MAX_SIDESTEPS = 100000
+      MAX_SIDESTEPS     = 100000
+      MAX_FILENAME_SIZE = 240
       #
       def filename_for(suite)
         basename = "#{@basename}-#{suite.name.gsub(/[^a-zA-Z0-9]+/, '-')}"
         suffix = "xml"
+        
+        # shorten basename if it exceeds 240 characters
+        # most filesystems have a 255 character limit
+        # so leave some room for the sidesteps
+        basename = basename[0..MAX_FILENAME_SIZE] if basename.length > MAX_FILENAME_SIZE
         
         # the initial filename, e.g. SPEC-MailsController.xml
         filename = [basename, suffix].join(".")

--- a/spec/ci/reporter/report_manager_spec.rb
+++ b/spec/ci/reporter/report_manager_spec.rb
@@ -36,4 +36,15 @@ describe "The ReportManager" do
     File.exist?(filename).should be_true
     File.open(filename) {|f| f.read.should == "<xml></xml>"}
   end
+
+  it "should shorten extremely long report filenames" do
+    reporter = CI::Reporter::ReportManager.new("spec")
+    suite = mock("test suite")
+    suite.should_receive(:name).and_return("some test suite name that goes on and on and on and on and on and on and does not look like it will end any time soon and just when you think it is almost over it just continues to go on and on and on and on and on until it is almost over but wait there is more and then el fin")
+    suite.should_receive(:to_xml).and_return("<xml></xml>")
+    reporter.write_report(suite)
+    filename = "#{REPORTS_DIR}/SPEC-some-test-suite-name-that-goes-on-and-on-and-on-and-on-and-on-and-on-and-does-not-look-like-it-will-end-any-time-soon-and-just-when-you-think-it-is-almost-over-it-just-continues-to-go-on.xml"
+    File.exist?(filename).should be_true
+    File.open(filename) {|f| f.read.should == "<xml></xml>"}
+  end
 end


### PR DESCRIPTION
I added code and spec to shorten filenames that will cause Errno::ENAMETOOLONG on filesystems that will only support 255 characters.

There were a couple other reports of this issue, but their solutions were not up to date with the latest version of ci_reporter.

I made the code compatible with the latest sidestep code and included a spec.
