### PR TITLE
Fix ref to README from gemspec.

### DIFF
--- a/ci_reporter.gemspec
+++ b/ci_reporter.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
   s.date = %q{2011-06-14}
   s.description = %q{CI::Reporter is an add-on to Test::Unit, RSpec and Cucumber that allows you to generate XML reports of your test, spec and/or feature runs. The resulting files can be read by a continuous integration system that understands Ant's JUnit report XML format, thus allowing your CI system to track test/spec successes and failures.}
   s.email = %q{nick@nicksieger.com}
-  s.extra_rdoc_files = ["History.txt", "README.txt", "LICENSE.txt"]
-  s.files = ["History.txt", "README.txt", "LICENSE.txt", "Rakefile", "stub.rake", "lib/ci/reporter/core.rb", "lib/ci/reporter/cucumber.rb", "lib/ci/reporter/report_manager.rb", "lib/ci/reporter/rspec.rb", "lib/ci/reporter/test_suite.rb", "lib/ci/reporter/test_unit.rb", "lib/ci/reporter/version.rb", "lib/ci/reporter/rake/cucumber.rb", "lib/ci/reporter/rake/cucumber_loader.rb", "lib/ci/reporter/rake/rspec.rb", "lib/ci/reporter/rake/rspec_loader.rb", "lib/ci/reporter/rake/test_unit.rb", "lib/ci/reporter/rake/test_unit_loader.rb", "spec/spec_helper.rb", "spec/ci/reporter/cucumber_spec.rb", "spec/ci/reporter/output_capture_spec.rb", "spec/ci/reporter/report_manager_spec.rb", "spec/ci/reporter/rspec_spec.rb", "spec/ci/reporter/test_suite_spec.rb", "spec/ci/reporter/test_unit_spec.rb", "spec/ci/reporter/rake/rake_tasks_spec.rb", "tasks/ci_reporter.rake"]
+  s.extra_rdoc_files = ["History.txt", "README.rdoc", "LICENSE.txt"]
+  s.files = ["History.txt", "README.rdoc", "LICENSE.txt", "Rakefile", "stub.rake", "lib/ci/reporter/core.rb", "lib/ci/reporter/cucumber.rb", "lib/ci/reporter/report_manager.rb", "lib/ci/reporter/rspec.rb", "lib/ci/reporter/test_suite.rb", "lib/ci/reporter/test_unit.rb", "lib/ci/reporter/version.rb", "lib/ci/reporter/rake/cucumber.rb", "lib/ci/reporter/rake/cucumber_loader.rb", "lib/ci/reporter/rake/rspec.rb", "lib/ci/reporter/rake/rspec_loader.rb", "lib/ci/reporter/rake/test_unit.rb", "lib/ci/reporter/rake/test_unit_loader.rb", "spec/spec_helper.rb", "spec/ci/reporter/cucumber_spec.rb", "spec/ci/reporter/output_capture_spec.rb", "spec/ci/reporter/report_manager_spec.rb", "spec/ci/reporter/rspec_spec.rb", "spec/ci/reporter/test_suite_spec.rb", "spec/ci/reporter/test_unit_spec.rb", "spec/ci/reporter/rake/rake_tasks_spec.rb", "tasks/ci_reporter.rake"]
   s.homepage = %q{http://caldersphere.rubyforge.org/ci_reporter}
-  s.rdoc_options = ["--main", "README.txt", "-SHN", "-f", "darkfish"]
+  s.rdoc_options = ["--main", "README.rdoc", "-SHN", "-f", "darkfish"]
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{caldersphere}
   s.rubygems_version = %q{1.5.1}


### PR DESCRIPTION
34922b3 renamed the README from .txt to .rdoc, but did not update the gemspec.
Among other things, this causes bundler to emit a warning when sourcing
ci_reporter from git.
