### PR TITLE
fix nil to_xs with CI_CAPTURE=off

### DIFF
--- a/lib/ci/reporter/test_suite.rb
+++ b/lib/ci/reporter/test_suite.rb
@@ -86,10 +86,10 @@ module CI
             tc.to_xml(builder)
           end
           builder.tag! "system-out" do
-            builder.text! self.stdout
+            builder.text!(self.stdout || '' )
           end
           builder.tag! "system-err" do
-            builder.text! self.stderr
+            builder.text!(self.stderr || '' )
           end
         end
       end

--- a/spec/ci/reporter/test_suite_spec.rb
+++ b/spec/ci/reporter/test_suite_spec.rb
@@ -53,6 +53,7 @@ end
 
 describe "TestSuite xml" do
   before(:each) do
+    ENV['CI_CAPTURE'] = nil
     @suite = CI::Reporter::TestSuite.new("example suite")
     @suite.assertions = 11
     begin
@@ -60,6 +61,14 @@ describe "TestSuite xml" do
     rescue => e
       @exception = e
     end
+  end
+
+  it "should render successfully with CI_CAPTURE off" do
+    ENV['CI_CAPTURE'] = 'off'
+    @suite.start
+    @suite.testcases << CI::Reporter::TestCase.new("example test")
+    @suite.finish
+    xml = @suite.to_xml
   end
 
   it "should contain Ant/JUnit-formatted description of entire suite" do


### PR DESCRIPTION
A fix for the below issue, seen when setting the environment variable CI_CAPTURE=off:

  1) TestSuite xml should render successfully with CI_CAPTURE off
     Failure/Error: xml = @suite.to_xml
     NoMethodError:
       undefined method `to_xs' for nil:NilClass
     # ./lib/ci/reporter/test_suite.rb:89:in`to_xml'
     # ./lib/ci/reporter/test_suite.rb:88:in `to_xml'
     # ./lib/ci/reporter/test_suite.rb:84:in`to_xml'
     # ./spec/ci/reporter/test_suite_spec.rb:71
