### PR TITLE
Mark skipped tests as skipped instead of failure

### DIFF
--- a/lib/ci/reporter/minitest.rb
+++ b/lib/ci/reporter/minitest.rb
@@ -211,7 +211,11 @@ module CI
 
       def fault(fault, type = nil, meth = nil)
         tc = @current_suite.testcases.last
-        tc.failures << Failure.new(fault, type, meth)
+        if :skip == type
+          tc.skipped = true
+        else
+          tc.failures << Failure.new(fault, type, meth)
+        end
       end
 
     end


### PR DESCRIPTION
Pretty simple tweak, there weren't any minitest acceptance tests so I just went ahead and made the change. 
