### PR TITLE
The reverted code will produce nil exceptions with rspec 1.3.1 and ci_reporter 1.7.0

### DIFF
--- a/lib/ci/reporter/rspec.rb
+++ b/lib/ci/reporter/rspec.rb
@@ -43,9 +43,9 @@ module CI
         !failure?
       end
 
-      def name() @example.metadata[:execution_result][:exception].class.name end
-      def message() @example.metadata[:execution_result][:exception].message end
-      def location() @example.metadata[:execution_result][:exception].backtrace.join("\n") end
+      def name() exception.class.name end
+      def message() exception.message end
+      def location() (exception.backtrace || ["No backtrace available"]).join("\n") end
     end
 
     class RSpec2Failure < RSpecFailure


### PR DESCRIPTION
...rter/commit/f700e0522c8f18182737a798aa4b357e4453a405#diff-0)"

This reverts commit eca73f1375d68a20bb3e2d5741fe9820332b0538.

Looking at the code and running it in the debugger, there is no instance variable named "@example", I've reverted the old commit. With this it works fine on jenkins with our setup with rspec 1.3.1. 
