### PR TITLE
Use const_defined? for checking a constant is defined

### DIFF
--- a/lib/ci/reporter/test_unit.rb
+++ b/lib/ci/reporter/test_unit.rb
@@ -13,8 +13,8 @@ module CI
     class Failure
       def self.new(fault)
         return TestUnitFailure.new(fault) if fault.kind_of?(Test::Unit::Failure)
-        return TestUnitSkipped.new(fault) if !(Test::Unit.constants & [:Omission, "Omission"]).empty? && (fault.kind_of?(Test::Unit::Omission) || fault.kind_of?(Test::Unit::Pending))
-        return TestUnitNotification.new(fault) if !(Test::Unit.constants & [:Notification, "Notification"]).empty? && fault.kind_of?(Test::Unit::Notification)
+        return TestUnitSkipped.new(fault) if Test::Unit.const_defined?(:Omission) && (fault.kind_of?(Test::Unit::Omission) || fault.kind_of?(Test::Unit::Pending))
+        return TestUnitNotification.new(fault) if Test::Unit.const_defined?(:Notification) && fault.kind_of?(Test::Unit::Notification)
         TestUnitError.new(fault)
       end
     end


### PR DESCRIPTION
#51 uses `!(Test::Unit.constants & [:Omission, "Omission"]).empty?` for

checking a constant is defined. But it's better that `Module#const_defined?`
is used for that propose.
