### PR TITLE
Add a line to output the RSpec seed with the test output

### DIFF
--- a/lib/ci/reporter/rspec.rb
+++ b/lib/ci/reporter/rspec.rb
@@ -185,6 +185,12 @@ module CI
         @formatter.dump_pending
       end
 
+      def seed(number)
+        output.puts
+        output.puts "Randomized with seed #{number}"
+        output.puts
+      end
+
       def close
         @formatter.close
       end


### PR DESCRIPTION
We use CIReporter with our Jenkins server, and recently while trying to debug a random failure I noticed that the seed wasn't being printed out.  I pulled in the code from [rspec-core](https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/formatters/base_text_formatter.rb#L96) that does this into your RSpec reporter class.
