### PR TITLE
make sure @suite is not nil before using it. This happens when the before(:suite) fails.

### DIFF
--- a/lib/ci/reporter/rspec.rb
+++ b/lib/ci/reporter/rspec.rb
@@ -203,8 +203,10 @@ module CI
       end
 
       def write_report
-        @suite.finish
-        @report_manager.write_report(@suite)
+        if @suite
+          @suite.finish
+          @report_manager.write_report(@suite)
+        end
       end
 
       def new_suite(name)


### PR DESCRIPTION
We had an issue with our RSpec config.before(:suite) block.  Was
getting:

NoMethodError: undefined method `finish' for nil:NilClass
  write_report at …/ci_reporter-1.7.0/lib/ci/reporter/rspec.rb:202
