### PR TITLE
Works around failure that occurs when features include tables

### DIFF
--- a/lib/ci/reporter/cucumber.rb
+++ b/lib/ci/reporter/cucumber.rb
@@ -116,9 +116,11 @@ module CI
           return
         end
         @test_case.finish
-        @test_case.failures << CucumberFailure.new(table_row) if table_row.failed?
-        test_suite.testcases << @test_case
-        @test_case = nil
+        if table_row.respond_to? :failed?
+          @test_case.failures << CucumberFailure.new(table_row) if table_row.failed?
+          test_suite.testcases << @test_case
+          @test_case = nil
+        end
       end
     end
   end


### PR DESCRIPTION
When using this on a feature that has a table, like:

```
    Given I input the following:
    | name  |  hedwig |
    | unit  |  inches |
    Then I should be angry
```

I get an error similar to the one in Issue #21 (copied below).

This provides a quick workaround so that the reporter doesn't fail, yet falls back to the existing logic when the table_row has the `failed?` method. I can't understand when that is the case, however, so this may be due for a refactor (or adding some tests demonstrating when that case arises).

```
undefined method `failed?' for #<Cucumber::Ast::Table::Cells:0x00000009db4eb8> (NoMethodError)
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/ci_reporter-1.7.0/lib/ci/reporter/cucumber.rb:119:in `after_table_row'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:173:in `block in send_to_all'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:171:in `each'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:171:in `send_to_all'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:164:in `broadcast'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:130:in `visit_table_row'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/table.rb:183:in `block in accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/table.rb:182:in `each'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/table.rb:182:in `accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:117:in `block in visit_multiline_arg'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:163:in `broadcast'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:116:in `visit_multiline_arg'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:106:in `block in visit_step_result'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:163:in `broadcast'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:104:in `visit_step_result'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/step_invocation.rb:43:in `visit_step_result'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/step_invocation.rb:39:in `accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:99:in `block in visit_step'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:163:in `broadcast'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:98:in `visit_step'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/step_collection.rb:15:in `block in accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/step_collection.rb:14:in `each'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/step_collection.rb:14:in `accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:93:in `block in visit_steps'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:163:in `broadcast'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:92:in `visit_steps'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/scenario.rb:55:in `block (2 levels) in accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:80:in `block (2 levels) in with_hooks'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:96:in `before_and_after'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:79:in `block in with_hooks'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:120:in `call'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:120:in `block (3 levels) in around'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/language_support/language_methods.rb:9:in `block in around'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/language_support/language_methods.rb:91:in `call'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/language_support/language_methods.rb:91:in `execute_around'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/language_support/language_methods.rb:8:in `around'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:119:in `block (2 levels) in around'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:117:in `call'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime/support_code.rb:117:in `around'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:91:in `around'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:78:in `with_hooks'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/scenario.rb:53:in `block in accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/scenario.rb:108:in `with_visitor'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/scenario.rb:47:in `accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:51:in `block in visit_feature_element'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:163:in `broadcast'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:50:in `visit_feature_element'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/feature.rb:43:in `block in accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/feature.rb:42:in `each'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/feature.rb:42:in `accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:20:in `block in visit_feature'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:163:in `broadcast'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:19:in `visit_feature'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/features.rb:29:in `block in accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/features.rb:17:in `each'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/features.rb:17:in `each'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/features.rb:28:in `accept'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:14:in `block in visit_features'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:163:in `broadcast'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/ast/tree_walker.rb:13:in `visit_features'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/runtime.rb:46:in `run!'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:43:in `execute!'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/lib/cucumber/cli/main.rb:20:in `execute'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/gems/cucumber-1.2.1/bin/cucumber:14:in `<top (required)>'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/bin/cucumber:23:in `load'
/usr/local/rvm/gems/ruby-1.9.3-p194@rails3/bin/cucumber:23:in `<main>'
rake aborted!
```
