### PR TITLE
do not search ancestors when checking Test::Unit.const_defined?

### DIFF
--- a/lib/ci/reporter/test_unit.rb
+++ b/lib/ci/reporter/test_unit.rb
@@ -13,8 +13,8 @@ module CI
     class Failure
       def self.new(fault)
         return TestUnitFailure.new(fault) if fault.kind_of?(Test::Unit::Failure)
-        return TestUnitSkipped.new(fault) if Test::Unit.const_defined?(:Omission) && (fault.kind_of?(Test::Unit::Omission) || fault.kind_of?(Test::Unit::Pending))
-        return TestUnitNotification.new(fault) if Test::Unit.const_defined?(:Notification) && fault.kind_of?(Test::Unit::Notification)
+        return TestUnitSkipped.new(fault) if Test::Unit.const_defined?(:Omission, false) && (fault.kind_of?(Test::Unit::Omission) || fault.kind_of?(Test::Unit::Pending))
+        return TestUnitNotification.new(fault) if Test::Unit.const_defined?(:Notification, false) && fault.kind_of?(Test::Unit::Notification)
         TestUnitError.new(fault)
       end
     end


### PR DESCRIPTION
Fix a false-positive detection of Test::Unit::Notification being defined due to const_defined? searching up the object heirarchy by default, which results in an uninitialized-constant-name-error at runtime if e.g. :Notification is defined elsewhere.

[1] pry(main)> Test::Unit.const_defined?(:Notification)
=> true
[2] pry(main)> Test::Unit.const_defined?(:Notification, false)
=> false
[5] pry(main)> Object.const_defined?(:Notification, false)
=> true

(Introduced in this commit: https://github.com/nicksieger/ci_reporter/commit/e7a0ff810a9cf21678ad6704b41fc3ad093d38ff
)
