### PR TITLE
Fixing LoadError for rspec/version

### DIFF
--- a/lib/ci/reporter/rspec.rb
+++ b/lib/ci/reporter/rspec.rb
@@ -16,8 +16,8 @@ module CI
         DocFormatter = ::RSpec::Core::Formatters::DocumentationFormatter
         # See https://github.com/nicksieger/ci_reporter/issues/76 and
         #     https://github.com/nicksieger/ci_reporter/issues/80
-        require 'rspec/version'
-        RSpec_2_12_0_bug = (::RSpec::Version::STRING == '2.12.0' &&
+        require 'rspec/core/version'
+        RSpec_2_12_0_bug = (::RSpec::Core::Version::STRING == '2.12.0' &&
                             !BaseFormatter.instance_methods(false).map(&:to_s).include?("format_backtrace"))
       rescue LoadError => first_error
         begin


### PR DESCRIPTION
- Fix for ci_reporter-1.8.2/lib/ci/reporter/rspec.rb:19:in `require': no such file to load -- rspec/version (LoadError) when running rake task. Instead of using 'rspec/version', we should be using 'rspec/core/version' as we are using rspec-core.
