### PR TITLE
Fixes filename too long on ecryptfs

### DIFF
--- a/lib/ci/reporter/report_manager.rb
+++ b/lib/ci/reporter/report_manager.rb
@@ -43,7 +43,8 @@ module CI #:nodoc:
         # shorten basename if it exceeds 240 characters
         # most filesystems have a 255 character limit
         # so leave some room for the sidesteps
-        basename = basename[0..MAX_FILENAME_SIZE] if basename.length > MAX_FILENAME_SIZE
+        max_filename_size = (ENV['MAX_FILENAME_SIZE'] || MAX_FILENAME_SIZE).to_i
+        basename = basename[0..max_filename_size] if basename.length > max_filename_size
         
         # the initial filename, e.g. SPEC-MailsController.xml
         filename = [basename, suffix].join(".")

--- a/spec/ci/reporter/report_manager_spec.rb
+++ b/spec/ci/reporter/report_manager_spec.rb
@@ -50,6 +50,20 @@ describe "The ReportManager" do
     File.open(filename) {|f| f.read.should == "<xml></xml>"}
   end
 
+  it "should shorten extremely long report filenames to custom length" do
+    reporter = CI::Reporter::ReportManager.new("spec")
+    suite = mock("test suite")
+    very_long_name = "some test suite name that goes on and on and on and on and on and on and does not look like it will end any time soon and just when you think it is almost over it just continues to go on and on and on and on and on until it is almost over but wait there is more and then el fin"
+    suite.should_receive(:name).and_return(very_long_name)
+    suite.should_receive(:to_xml).and_return("<xml></xml>")
+    ENV['MAX_FILENAME_SIZE'] = '170'
+    reporter.write_report(suite)
+    filename = "#{REPORTS_DIR}/SPEC-#{very_long_name}"[0..170].gsub(/\s/, '-') + ".xml"
+    filename.length.should be_<= 188
+    File.exist?(filename).should be_true
+    File.open(filename) {|f| f.read.should == "<xml></xml>"}
+  end
+
   it "sidesteps existing files by adding an incrementing number" do
     filename = "#{REPORTS_DIR}/SPEC-colliding-test-suite-name.xml"
     FileUtils.mkdir_p(File.dirname(filename))


### PR DESCRIPTION
Fixes problems with encrypted partitions, the default
assumes the max filename length to be ~255, but this
is not always the case.
