### PR TITLE
add license information to the gemspec

### DIFF
--- a/ci_reporter.gemspec
+++ b/ci_reporter.gemspec
@@ -57,4 +57,5 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<hoe>, ["~> 2.12"])
     s.add_dependency(%q<rdoc>, ["~> 3.10"])
   end
+  s.license = "MIT"
 end


### PR DESCRIPTION
This way it can be queried using the rubygems.org API
