### PR TITLE
Allows cucumber rake task to find steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage*
 acceptance/reports
 pkg
 doc
+/.bundle/

--- a/lib/ci/reporter/rake/cucumber.rb
+++ b/lib/ci/reporter/rake/cucumber.rb
@@ -11,9 +11,7 @@ namespace :ci do
     end
 
     task :cucumber => :cucumber_report_cleanup do
-      cuke_opts = ["--require", CI::Reporter.maybe_quote_filename("#{File.dirname(__FILE__)}/cucumber_loader.rb"),
-        "--format", "CI::Reporter::Cucumber"].join(" ")
-      ENV["CUCUMBER_OPTS"] = "#{ENV['CUCUMBER_OPTS']} #{cuke_opts}"
+      ENV["CUCUMBER_OPTS"] = "#{ENV['CUCUMBER_OPTS']} --format CI::Reporter::Cucumber"
     end
   end
 end

--- a/spec/ci/reporter/rake/rake_tasks_spec.rb
+++ b/spec/ci/reporter/rake/rake_tasks_spec.rb
@@ -94,12 +94,17 @@ describe "ci_reporter ci:setup:cucumber task" do
 
   it "should set ENV['CUCUMBER_OPTS'] to include cucumber formatter args" do
     @rake["ci:setup:cucumber"].invoke
-    ENV["CUCUMBER_OPTS"].should =~ /--require.*cucumber_loader.*--format.*CI::Reporter::Cucumber/
+    ENV["CUCUMBER_OPTS"].should =~ /--format\s+CI::Reporter::Cucumber/
+  end
+
+  it "should not set ENV['CUCUMBER_OPTS'] to require cucumber_loader" do
+    @rake["ci:setup:cucumber"].invoke
+    ENV["CUCUMBER_OPTS"].should_not =~ /.*--require\s+\S*cucumber_loader.*/
   end
 
   it "should append to ENV['CUCUMBER_OPTS'] if it already contains a value" do
     ENV["CUCUMBER_OPTS"] = "somevalue".freeze
     @rake["ci:setup:cucumber"].invoke
-    ENV["CUCUMBER_OPTS"].should =~ /somevalue.*--require.*cucumber_loader.*--format.*CI::Reporter::Cucumber/
+    ENV["CUCUMBER_OPTS"].should =~ /somevalue.*\s--format\s+CI::Reporter::Cucumber/
   end
 end


### PR DESCRIPTION
Requiring the cucumber_loader directly causes cucumber to be unable to find
the steps definitions.

This should fix issue #38.
