### PR TITLE
be_<= does not work now. use be <= instead

### DIFF
--- a/spec/ci/reporter/report_manager_spec.rb
+++ b/spec/ci/reporter/report_manager_spec.rb
@@ -45,7 +45,7 @@ describe "The ReportManager" do
     suite.should_receive(:to_xml).and_return("<xml></xml>")
     reporter.write_report(suite)
     filename = "#{REPORTS_DIR}/SPEC-#{very_long_name}"[0..CI::Reporter::ReportManager::MAX_FILENAME_SIZE].gsub(/\s/, '-') + ".xml"
-    filename.length.should be_<= 255
+    filename.length.should be <= 255
     File.exist?(filename).should be_true
     File.open(filename) {|f| f.read.should == "<xml></xml>"}
   end


### PR DESCRIPTION
With latest rspec, test fails as below

```
Failures:

  1) The ReportManager should shorten extremely long report filenames
     Failure/Error: filename.length.should be_<= 255
     NoMethodError:
       undefined method `<=' for #<RSpec::Matchers::BuiltIn::BePredicate:0x007fb975240de8>
     # ./spec/ci/reporter/report_manager_spec.rb:48:in `block (2 levels) in <top (required)>'
```
