### PR TITLE
Feature: RSpec 3 support

### DIFF
--- a/lib/ci/reporter/rspec.rb
+++ b/lib/ci/reporter/rspec.rb
@@ -92,7 +92,7 @@ module CI
       end
     end
 
-    class RSpecFormatter < ::RSpec::Core::Formatters::BaseFormatter
+    class RSpecFormatter < ::RSpec::Core::Formatters::ProgressFormatter
       attr_accessor :suite, :report_manager
       if ::RSpec::Core::Formatters.respond_to?(:register)
         ::RSpec::Core::Formatters.register self, :example_group_started,
@@ -118,6 +118,7 @@ module CI
       end
 
       def example_passed(notification)
+        super
         spec = @suite.testcases.last
         spec.finish
         spec.name = description_for(notification.example)


### PR DESCRIPTION
RSpec 3 has completely overhauled the formatter system using a notification system that allows developers to optionally register interest in particular notifications instead of implementing them all.

Please read: http://myronmars.to/n/dev-blog/2013/07/the-plan-for-rspec-3 for more information.

Some points:
- Currently the RSpec class is toggled depending on the version of RSpec. I am not if this is the best way to do it, it does maintain the backwards compatibility but perhaps it would be better to toggle the class used in the rake task instead?
- There are no tests in place for the RSpec 3 formatter class - I had a look at the current test suite but wasn't sure of the best way to add them.
