### PR TITLE
add timestamp attribute to test suite

### DIFF
--- a/lib/ci/reporter/test_suite.rb
+++ b/lib/ci/reporter/test_suite.rb
@@ -51,7 +51,7 @@ module CI
     end
 
     # Basic structure representing the running of a test suite.  Used to time tests and store results.
-    class TestSuite < Struct.new(:name, :tests, :time, :failures, :errors, :skipped, :assertions)
+    class TestSuite < Struct.new(:name, :timestamp, :tests, :time, :failures, :errors, :skipped, :assertions)
       attr_accessor :testcases
       attr_accessor :stdout, :stderr
       def initialize(name)
@@ -72,6 +72,7 @@ module CI
       def finish
         self.tests = testcases.size
         self.time = Time.now - @start
+        self.timestamp = @start.iso8601
         self.failures = testcases.inject(0) {|sum,tc| sum += tc.failures.select{|f| f.failure? }.size }
         self.errors = testcases.inject(0) {|sum,tc| sum += tc.failures.select{|f| f.error? }.size }
         self.skipped = testcases.inject(0) {|sum,tc| sum += (tc.skipped? ? 1 : 0) }

--- a/spec/ci/reporter/test_suite_spec.rb
+++ b/spec/ci/reporter/test_suite_spec.rb
@@ -102,6 +102,7 @@ describe "TestSuite xml" do
     testsuite = testsuite.first
     testsuite.attributes["name"].should == "example suite"
     testsuite.attributes["assertions"].should == "11"
+    testsuite.attributes["timestamp"].should match(/(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})[+-](\d{2})\:(\d{2})/)
 
     testcases = testsuite.elements.to_a("testcase")
     testcases.length.should == 4


### PR DESCRIPTION
it supports timestamp of start time in test suite out of Apache ant task [XMLJunitResultFormatter](http://svn.apache.org/viewvc/ant/core/trunk/src/main/org/apache/tools/ant/taskdefs/optional/junit/XMLJUnitResultFormatter.java?view=markup). see line 136 ~ 139.

This attribute is very helpful for tracing test performance.
