### PR TITLE
Restructure tests for the different supported gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
+rvm:
+  - 1.9.3
+  - 2.0
+  - 2.1
+  - jruby
+
+gemfile:
+  - Gemfile
+  - gemfiles/Gemfile.spinach
+  - gemfiles/Gemfile.minitest
+  - gemfiles/Gemfile.test-unit
+  - gemfiles/Gemfile.cucumber
+  - gemfiles/Gemfile.rspec
+
 matrix:
-  include:
-    - rvm: 1.9.3
-    - rvm: 2.0
-    - rvm: 2.1
+  exclude:
     - rvm: jruby
-      env: CI_REPORTER_NO_SPINACH=1
+      gemfile: gemfiles/Gemfile.spinach
+
 branches:
   only:
     - master

--- a/Rakefile
+++ b/Rakefile
@@ -62,25 +62,33 @@ end
 
 namespace :generate do
   task :test_unit do
+    if Gem.loaded_specs['test-unit']
     run_ruby_acceptance "-rci/reporter/rake/test_unit_loader acceptance/test_unit_example_test.rb"
+    end
   end
 
   task :minitest do
+    if Gem.loaded_specs['minitest']
     run_ruby_acceptance "-rci/reporter/rake/minitest_loader acceptance/minitest_example_test.rb"
+    end
   end
 
   task :rspec do
+    if Gem.loaded_specs['rspec-core']
     rspec = "#{Gem.loaded_specs['rspec-core'].gem_dir}/exe/rspec"
     run_ruby_acceptance "-S #{rspec} --require ci/reporter/rake/rspec_loader --format CI::Reporter::RSpec acceptance/rspec_example_spec.rb"
+    end
   end
 
   task :cucumber do
+    if Gem.loaded_specs['cucumber']
     cucumber = "#{Gem.loaded_specs['cucumber'].gem_dir}/bin/cucumber"
     run_ruby_acceptance "-rci/reporter/rake/cucumber_loader -S #{cucumber} --format CI::Reporter::Cucumber acceptance/cucumber"
+    end
   end
 
   task :spinach do
-    unless ENV['CI_REPORTER_NO_SPINACH']
+    if Gem.loaded_specs['spinach']
     spinach = "#{Gem.loaded_specs['spinach'].gem_dir}/bin/spinach"
     run_ruby_acceptance "-I../../lib -rci/reporter/rake/spinach_loader -S #{spinach} -r ci_reporter -f acceptance/spinach/features"
     end

--- a/acceptance/verification_spec.rb
+++ b/acceptance/verification_spec.rb
@@ -8,6 +8,7 @@ require 'rexml/document'
 
 REPORTS_DIR = File.dirname(__FILE__) + '/reports'
 
+if Gem.loaded_specs['test-unit']
 describe "Test::Unit acceptance" do
   it "should generate two XML files" do
     File.exist?(File.join(REPORTS_DIR, 'TEST-TestUnitExampleTestOne.xml')).should == true
@@ -42,7 +43,9 @@ describe "Test::Unit acceptance" do
     doc.root.elements.to_a("/testsuite/testcase/failure").size.should == 0
   end
 end
+end
 
+if Gem.loaded_specs['minitest']
 describe "MiniTest::Unit acceptance" do
   it "should generate two XML files" do
     File.exist?(File.join(REPORTS_DIR, 'TEST-MiniTestExampleTestOne.xml')).should == true
@@ -77,7 +80,9 @@ describe "MiniTest::Unit acceptance" do
     doc.root.elements.to_a("/testsuite/testcase/failure").size.should == 0
   end
 end
+end
 
+if Gem.loaded_specs['rspec-core']
 describe "RSpec acceptance" do
   it "should generate two XML files" do
     File.exist?(File.join(REPORTS_DIR, 'SPEC-RSpec-example.xml')).should == true
@@ -107,7 +112,9 @@ describe "RSpec acceptance" do
     doc.root.elements.to_a("/testsuite/testcase").size.should == 1
   end
 end
+end
 
+if Gem.loaded_specs['cucumber']
 describe "Cucumber acceptance" do
   it "should generate one XML file" do
     File.exist?(File.join(REPORTS_DIR, 'FEATURES-Example-Cucumber-feature.xml')).should == true
@@ -142,8 +149,9 @@ describe "Cucumber acceptance" do
     end
   end
 end
+end
 
-unless ENV['CI_REPORTER_NO_SPINACH']
+if Gem.loaded_specs['spinach']
 describe "Spinach acceptance" do
   it "should generate one XML file" do
     File.exist?(File.join(REPORTS_DIR, 'FEATURES-Example-Spinach-feature.xml')).should == true

--- a/ci_reporter.gemspec
+++ b/ci_reporter.gemspec
@@ -26,32 +26,20 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<builder>, [">= 2.1.2"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<hoe-git>, ["~> 1.5.0"])
-      s.add_development_dependency(%q<cucumber>, [">= 1.3.3"])
       s.add_development_dependency(%q<rspec>, ["~> 2.0"])
-      s.add_development_dependency(%q<test-unit>, ["> 2.4.9"])
-      s.add_development_dependency(%q<minitest>, ["~> 2.2.0"])
-      s.add_development_dependency(%q<spinach>, [">= 0.8.7"]) unless ENV['CI_REPORTER_NO_SPINACH']
       s.add_development_dependency(%q<hoe>, ["~> 3.7"])
     else
       s.add_dependency(%q<builder>, [">= 2.1.2"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<hoe-git>, ["~> 1.5.0"])
-      s.add_dependency(%q<cucumber>, [">= 1.3.3"])
       s.add_dependency(%q<rspec>, ["~> 2.0"])
-      s.add_dependency(%q<test-unit>, ["> 2.4.9"])
-      s.add_dependency(%q<minitest>, ["~> 2.2.0"])
-      s.add_dependency(%q<spinach>, [">= 0.8.7"]) unless ENV['CI_REPORTER_NO_SPINACH']
       s.add_dependency(%q<hoe>, ["~> 3.7"])
     end
   else
     s.add_dependency(%q<builder>, [">= 2.1.2"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<hoe-git>, ["~> 1.5.0"])
-    s.add_dependency(%q<cucumber>, [">= 1.3.3"])
     s.add_dependency(%q<rspec>, ["~> 2.0"])
-    s.add_dependency(%q<test-unit>, ["> 2.4.9"])
-    s.add_dependency(%q<minitest>, ["~> 2.2.0"])
-    s.add_dependency(%q<spinach>, [">= 0.8.7"]) unless ENV['CI_REPORTER_NO_SPINACH']
     s.add_dependency(%q<hoe>, ["~> 3.7"])
   end
 end

--- a/gemfiles/.gitignore
+++ b/gemfiles/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.*.lock

--- a/gemfiles/Gemfile.cucumber
+++ b/gemfiles/Gemfile.cucumber
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rspec', '~> 2.0'
+gem 'cucumber', ">= 1.3.3"
+gem 'ci_reporter', path: '..'

--- a/gemfiles/Gemfile.minitest
+++ b/gemfiles/Gemfile.minitest
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rspec', '~> 2.0'
+gem 'minitest', "~> 2.2.0"
+gem 'ci_reporter', path: '..'

--- a/gemfiles/Gemfile.rspec
+++ b/gemfiles/Gemfile.rspec
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rspec', '~> 2.0'
+gem 'ci_reporter', path: '..'

--- a/gemfiles/Gemfile.spinach
+++ b/gemfiles/Gemfile.spinach
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rspec', '~> 2.0'
+gem 'spinach', '>= 0.8.7'
+gem 'ci_reporter', path: '..'

--- a/gemfiles/Gemfile.test-unit
+++ b/gemfiles/Gemfile.test-unit
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'rspec', '~> 2.0'
+gem 'test-unit', "> 2.4.9"
+gem 'ci_reporter', path: '..'

--- a/spec/ci/reporter/cucumber_spec.rb
+++ b/spec/ci/reporter/cucumber_spec.rb
@@ -2,6 +2,8 @@
 # See the file LICENSE.txt included with the distribution for
 # software license details.
 
+if Gem.loaded_specs['cucumber']
+
 require File.dirname(__FILE__) + "/../../spec_helper.rb"
 require 'ci/reporter/cucumber'
 
@@ -227,4 +229,5 @@ describe "The Cucumber reporter" do
       end
     end
   end
+end
 end

--- a/spec/ci/reporter/rspec_spec.rb
+++ b/spec/ci/reporter/rspec_spec.rb
@@ -2,7 +2,10 @@
 # See the file LICENSE.txt included with the distribution for
 # software license details.
 
+if Gem.loaded_specs['rspec-core']
+
 require File.dirname(__FILE__) + "/../../spec_helper.rb"
+require 'ci/reporter/rspec'
 require 'stringio'
 
 describe "The RSpec reporter" do
@@ -148,4 +151,5 @@ describe "The RSpec reporter" do
       failure.location.should_not be_nil
     end
   end
+end
 end

--- a/spec/ci/reporter/test_unit_spec.rb
+++ b/spec/ci/reporter/test_unit_spec.rb
@@ -2,7 +2,11 @@
 # See the file LICENSE.txt included with the distribution for
 # software license details.
 
+if Gem.loaded_specs['test-unit']
+
 require File.dirname(__FILE__) + "/../../spec_helper.rb"
+require 'ci/reporter/test_unit'
+Test::Unit.run = true
 
 describe "The TestUnit reporter" do
   before(:each) do
@@ -149,4 +153,5 @@ describe "The TestUnit reporter" do
     @suite.testcases.length.should == 1
     @suite.testcases.first.name.should == "some unknown test"
   end
+end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,5 @@ unless defined?(CI_REPORTER_LIB)
 end
 
 require 'ci/reporter/core'
-require 'ci/reporter/test_unit'
-require 'ci/reporter/rspec'
 
-Test::Unit.run = true
 REPORTS_DIR = File.dirname(__FILE__) + "/reports" unless defined?(REPORTS_DIR)


### PR DESCRIPTION
Leverage Travis CI's multiple Gemfile ability and create a specific
Gemfile for each supported testing framework. This gives us the
ability to test against multiple versions of a framework, and also
helps draw lines in the sand where the pieces fit together.
