### PR TITLE
Prevent flaky tests by restoring the CI_CAPTURE variable

### DIFF
--- a/spec/ci/reporter/test_suite_spec.rb
+++ b/spec/ci/reporter/test_suite_spec.rb
@@ -71,6 +71,10 @@ module CI::Reporter
         suite.assertions = 11
       end
 
+      after(:each) do
+        ENV['CI_CAPTURE'] = nil
+      end
+
       it "renders successfully with CI_CAPTURE off" do
         ENV['CI_CAPTURE'] = 'off'
         suite.start


### PR DESCRIPTION
Closes #125
