### PR TITLE
rspec 3.1.2 doesn't accept Rake::FileList for pattern=

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@ require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:rspec) do |t|
-  t.pattern = FileList['spec']
   t.rspec_opts = "--color"
 end
 


### PR DESCRIPTION
This fixes the CI build as described in #148
