### PR TITLE
include the suite name when filtering test methods

### DIFF
--- a/lib/ci/reporter/minitest.rb
+++ b/lib/ci/reporter/minitest.rb
@@ -162,7 +162,9 @@ module CI
         filter = options[:filter] || '/./'
         filter = Regexp.new $1 if filter =~ /\/(.*)\//
 
-        suite.send("#{type}_methods").grep(filter)
+        suite.send("#{type}_methods").find_all do |m|
+          filter === m || filter === "#{suite}##{m}"
+        end
       end
 
       def run_test(suite, method)


### PR DESCRIPTION
In minitest v4.7.3 `MiniTest::Unit` tests the filters against the method names and the suite name followed by method name. This change makes it work the same way for `CI::Reporter::Runner`.

seattlerb/minitest@644a52fd0aa0205c8767829ca8afbd8c158f9ff2 is the last revision before v5.0.0
https://github.com/seattlerb/minitest/blob/644a52fd0aa0205c8767829ca8afbd8c158f9ff2/lib/minitest/unit.rb#L909-913
